### PR TITLE
fix: custom cell  typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panenco/ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Panenco UI",
   "module": "lib/ui.esm.js",
   "main": "lib/ui.esm.js",

--- a/src/components/responsive-table/types.ts
+++ b/src/components/responsive-table/types.ts
@@ -47,8 +47,8 @@ export interface TableState {
   containerWidth?: number;
 }
 
-export type CustomCellProps = {
-  row: RowType;
+export type CustomCellProps<T = Record<string, any>> = {
+  row: RowType<T>;
   rowIndex: number | string;
   cellIndex: number;
   accessor: string;


### PR DESCRIPTION
in RowType should be possible to get type from CustomCellProps, otherwise, a row will have type as { [key: string]: any }

<img width="418" alt="Screenshot 2021-07-02 at 10 02 45" src="https://user-images.githubusercontent.com/34914550/124234453-b6f4dd00-db1c-11eb-85c5-20479f87cab8.png">
