### PR TITLE
feat: add property for customizing pointer color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@panenco/ui",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Panenco UI",
   "module": "lib/ui.esm.js",
   "main": "lib/ui.esm.js",

--- a/src/components/radiobutton/README.md
+++ b/src/components/radiobutton/README.md
@@ -26,14 +26,15 @@ This component inherits the attributes of the **input** element and extends the 
 - error - add this prop when smth went wrong;
 - wrapperProps - it's props which will be added to wrapper component;
 - inputProps - it's props which will be added to input component;
-- wrapperProps - it's props which will be added to wrapper component;
-- ref - wrapper ref
+- pointColor - customizing point color for different cases;
+- ref - wrapper ref;
 
 | propName     | propType                  | defaultValue      | isRequired |
 | ------------ | ------------------------- | ----------------- | ---------- |
 | error        | string                    | -                 | -          |
 | label        | string                    | -                 | -          |
 | id           | string or (any)           | generate uniqueID | -          |
+| pointColor   | string                    | -                 | -          |
 | inputProps   | React.InputHTMLAttributes | -                 | -          |
 | wrapperProps | React.LabelHTMLAttributes | -                 | -          |
 | ref          | React.RefObject           | -                 | -          |

--- a/src/components/radiobutton/index.tsx
+++ b/src/components/radiobutton/index.tsx
@@ -14,19 +14,23 @@ interface WrapperProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
 export interface RadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  pointColor?: string;
   inputProps?: InputPropsType; // will be removed in next version
   wrapperProps?: WrapperProps;
 }
 
 export const Radio = React.forwardRef<HTMLLabelElement, RadioButtonProps>(
-  ({ label, id, className, checked, value, inputProps, wrapperProps, disabled, error, ...props }, ref): JSX.Element => {
+  (
+    { label, id, className, checked, value, inputProps, wrapperProps, disabled, error, pointColor, ...props },
+    ref,
+  ): JSX.Element => {
     const theme = useTheme();
     const { mode } = useMode();
     const uniqueID = idGenerator();
     const defaultId = id || uniqueID;
 
     return (
-      <StyledRadio theme={theme} mode={mode} ref={ref} error={error} {...wrapperProps}>
+      <StyledRadio theme={theme} mode={mode} ref={ref} error={error} pointColor={pointColor} {...wrapperProps}>
         <label className={cx('label', disabled && 'labelDisabled', className)} htmlFor={id || defaultId}>
           <input
             type="radio"

--- a/src/components/radiobutton/style.ts
+++ b/src/components/radiobutton/style.ts
@@ -28,6 +28,9 @@ export const StyledRadio = styled.div`
 
     & .point {
       background-color: ${(props: any): string => {
+        if (props.pointColor) {
+          return props.pointColor;
+        }
         if (props.error) {
           return props.theme.colors.error;
         }
@@ -49,6 +52,9 @@ export const StyledRadio = styled.div`
       .container {
         transition: 0.3s;
         border-color: ${(props: any): string => {
+          if (props.pointColor) {
+            return props.pointColor;
+          }
           if (props.error) {
             return props.theme.colors.error;
           }
@@ -60,7 +66,8 @@ export const StyledRadio = styled.div`
     .container {
       background-color: transparent;
       border: 2px solid
-        ${(props: any): string => (props.error ? props.theme.colors.error : props.theme.colors.secondary)};
+        ${(props: any): string =>
+          props.pointColor || (props.error ? props.theme.colors.error : props.theme.colors.secondary)};
       border-radius: 50%;
       cursor: pointer;
       display: flex;
@@ -84,6 +91,9 @@ export const StyledRadio = styled.div`
     .radiobox:checked + .container {
       border: 2px solid
         ${(props: any): string => {
+          if (props.pointColor) {
+            return props.pointColor;
+          }
           if (props.error) {
             return props.theme.colors.error;
           }
@@ -101,6 +111,9 @@ export const StyledRadio = styled.div`
         & + .container {
           border: 2px solid
             ${(props: any): string => {
+              if (props.pointColor) {
+                return props.pointColor;
+              }
               if (props.error) {
                 return props.theme.colors.error;
               }
@@ -109,6 +122,9 @@ export const StyledRadio = styled.div`
 
           & > .point {
             background-color: ${(props: any): string => {
+              if (props.pointColor) {
+                return props.pointColor;
+              }
               if (props.error) {
                 return props.theme.colors.error;
               }


### PR DESCRIPTION
sometimes we should have a possibility to change the "pointer" color (it can be not the same color as by default) e.g. if we create a quiz and want to show for a user result of his choice and pointer can be green, red, orange or whatever, so it's a good point to add some property for customizing "pointer" color 

