### PR TITLE
Fix chip and text behaviour

### DIFF
--- a/src/components/chip/README.md
+++ b/src/components/chip/README.md
@@ -28,23 +28,16 @@ const render  = () => {
 This component inherits the attributes of the **button** element and extends the functionality with next properties.
 
 - checked - set checked flag for chip;
-- icon - icon which will be rendered;
+- icon - icon which will be rendered when checked;
+- uncheckedIcon - icon which will be rendered when unchecked;
 - onIconClick - event for icon element;
-- iconClassName - override icon styles;
-- iconSize - icon size in px;
-- textSize - text size(by default **typography.s** from your theme);
-- textWeight - text weight;
-- textTypography - object with 2 properties (weight and size);
+- disabled - is disabled
 - ref - ref;
 
-| propName       | propType                                                      | defaultValue                                   | isRequired |
-| -------------- | ------------------------------------------------------------- | ---------------------------------------------- | ---------- |
-| checked        | boolean                                                       | -                                              | -          |
-| onIconClick    | React.MouseEvent                                              | -                                              | -          |
-| icon           | HTMLObjectElement                                             | -                                              | -          |
-| iconClassName  | string                                                        | -                                              | -          |
-| textSize       | {textSize: string, lineHeight: size}                          | theme.typography.sizes.m                       | -          |
-| textWeight     | string                                                        | bold (for checked) and regular (for unchecked) | -          |
-| textTypography | {size: {textSize: string, lineHeight: size} , weight: string} | -                                              | -          |
-| iconClassName  | string (number)                                               | -                                              | -          |
-| ref            | React.RefObject                                               | -                                              | -          |
+| propName      | propType                 | defaultValue       | isRequired |
+| ------------- | ------------------------ | ------------------ | ---------- |
+| checked       | boolean                  | -                  | -          |
+| onIconClick   | React.MouseEvent => void | -                  | -          |
+| icon          | HTMLObjectElement        | Icon.icons.checked | -          |
+| uncheckedIcon | HTMLObjectElement        | -                  | -          |
+| ref           | React.RefObject          | -                  | -          |

--- a/src/components/chip/index.tsx
+++ b/src/components/chip/index.tsx
@@ -8,21 +8,9 @@ import { StyledChip } from './style';
 export interface ChipProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   checked?: boolean;
   icon?: HTMLObjectElement;
+  uncheckedIcon?: HTMLObjectElement;
   onIconClick?: any;
   iconClassName?: string;
-  iconSize?: number | string;
-  textSize?: {
-    textSize: string;
-    lineHeight: string;
-  };
-  textWeight?: string;
-  textTypography?: {
-    weight: string;
-    size: {
-      textSize: string;
-      lineHeight: string;
-    };
-  };
 }
 
 export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
@@ -35,17 +23,14 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       style,
       icon = Icon.icons.success,
       onIconClick,
-      iconClassName,
-      iconSize,
-      textSize,
-      textWeight,
-      textTypography,
+      uncheckedIcon,
       ...props
     }: ChipProps,
     ref,
   ): JSX.Element => {
     const theme = useTheme();
     const { mode } = useMode();
+
     const handleIconClick = (e: React.UIEvent): void => {
       e.persist();
       e.stopPropagation();
@@ -53,6 +38,7 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
       onIconClick(e);
     };
 
+    const iconComponent = checked ? icon : uncheckedIcon || null;
     return (
       <StyledChip
         type="button"
@@ -60,26 +46,21 @@ export const Chip = React.forwardRef<HTMLButtonElement, ChipProps>(
         aria-checked={checked}
         disabled={disabled}
         checked={checked}
-        className={cx(disabled && 'chipDisabled', className)}
+        className={cx(disabled && 'chipDisabled', checked && 'chipChecked', className)}
         style={style}
         theme={theme}
         mode={mode}
         ref={ref}
-        iconSize={iconSize}
         {...props}
       >
         <Text
-          weight={
-            textTypography?.weight || textWeight || checked
-              ? theme.typography.weights.bold
-              : theme.typography.weights.regular
-          }
-          size={textTypography?.size || textSize || theme.typography.sizes.m}
+          weight={checked ? theme.typography.weights.bold : theme.typography.weights.regular}
+          size={theme.typography.sizes.m}
           className="labelTitle"
         >
           {children}
         </Text>
-        {checked && <Icon icon={icon} onClick={onIconClick && handleIconClick} className={iconClassName} />}
+        {iconComponent && <Icon icon={iconComponent} onClick={onIconClick && handleIconClick} />}
       </StyledChip>
     );
   },

--- a/src/components/chip/style.ts
+++ b/src/components/chip/style.ts
@@ -65,12 +65,10 @@ export const StyledChip = styled.button<{
     line-height: 16px;
   }
 
-  & > svg {
-    width: ${(props: any): string => (props.iconSize ? `${props.iconSize}px` : '16px')};
-    height: ${(props: any): string => (props.iconSize ? `${props.iconSize}px` : '16px')};
+  .svg {
+    width: 16px;
+    height: 16px;
     margin-left: 10px;
-    color: ${(props: any): string =>
-      props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.light};
   }
 
   &.chipDisabled {

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -86,7 +86,7 @@ export const Icon = React.forwardRef<any, IconProps>(
     const defaultSize = icon.viewBox?.split(' ')[3] || 16;
     return (
       <StyledSVG
-        className={cx(disabled && 'disabled', (size || width || height) && 'svg', className)}
+        className={cx(disabled && 'disabled', 'svg', className)}
         width={sizeToString(width || size || defaultSize)}
         height={sizeToString(height || size || defaultSize)}
         viewBox={icon.viewBox}

--- a/src/components/select/chips-component.tsx
+++ b/src/components/select/chips-component.tsx
@@ -8,31 +8,10 @@ export interface ChipsProps extends SelectProps, InputComponent {
   value?: any;
   chipIconSize?: number | string;
   chipIcon?: any;
-  chipTextWeight?: string;
-  chipTextSize?: {
-    textSize: string;
-    lineHeight: string;
-  };
-  chipTextTypography?: {
-    size: {
-      textSize: string;
-      lineHeight: string;
-    };
-    weight: string;
-  };
   onDeleteOption?: any;
 }
 
-const ChipsComponent = ({
-  value,
-  onDeleteOption,
-  chipIconSize,
-  chipTextSize,
-  chipTextWeight,
-  chipTextTypography,
-  chipIcon,
-  getOptionLabel,
-}: ChipsProps): JSX.Element => (
+const ChipsComponent = ({ value, onDeleteOption, chipIcon, getOptionLabel }: ChipsProps): JSX.Element => (
   <div className="isMultiActiveChips">
     {value?.map((option) => {
       if (!option) return null;
@@ -52,10 +31,6 @@ const ChipsComponent = ({
               onDeleteOption(option);
             }
           }}
-          iconSize={chipIconSize}
-          textSize={chipTextSize}
-          textWeight={chipTextWeight}
-          textTypography={chipTextTypography}
         >
           {chipLabel}
         </Chip>

--- a/src/components/text/README.md
+++ b/src/components/text/README.md
@@ -23,15 +23,15 @@ const YourComponent = () => {
 - `weight` - font weight
 - `color` - font color
 - `children` - text content
-- `component` - paragraph or span (p or span)
+- `component` - p, span or any custom component
 
-| propName  | propType | defaultValue | isRequired |
-| --------- | -------- | ------------ | ---------- |
-| size      | string   | s            | -          |
-| weight    | string   | inherit      | -          |
-| color     | string   | inherit      | -          |
-| component | string   | -            | -          |
-| children  | node     | -            | +          |
+| propName  | propType                                     | defaultValue | isRequired |
+| --------- | -------------------------------------------- | ------------ | ---------- |
+| size      | string                                       | s            | -          |
+| weight    | string                                       | inherit      | -          |
+| color     | string                                       | inherit      | -          |
+| component | keyof React.ReactHTML or React.ComponentType | span         | -          |
+| children  | node                                         | -            | +          |
 
 ### Sizes
 

--- a/src/components/text/index.tsx
+++ b/src/components/text/index.tsx
@@ -8,55 +8,14 @@ export interface TextProps extends React.HTMLAttributes<HTMLElement> {
   color?: string | EnumColors;
   weight?: string | number;
   size?: string | TextSize;
-  component?: 'p' | 'span';
+  component?: keyof React.ReactHTML | React.ComponentType;
 }
 
-const StyledSpan = styled.span<{
+const StyledComponent = styled.span<{
   theme: PUITheme;
   size?: string | TextSize;
   weight?: string | number;
-}>`
-  display: inline-block;
-  font-size: ${(props: any): number | string => {
-    if (typeof props.size === 'string' && Object.keys(props.theme.typography.sizes).includes(props.size)) {
-      return props.theme.typography.sizes[props.size].textSize;
-    }
-    if (props.size === 'inherit') {
-      return 'inherit';
-    }
-    return props.size.textSize;
-  }};
-  line-height: ${(props: any): string | number => {
-    if (typeof props.size === 'string' && Object.keys(props.theme.typography.sizes).includes(props.size)) {
-      return props.theme.typography.sizes[props.size].lineHeight;
-    }
-    if (props.size === 'inherit') {
-      return 'inherit';
-    }
-    return props.size.lineHeight;
-  }};
-  color: ${(props: any): string => {
-    if (typeof props.size === 'string' && Object.keys(props.theme.colors).includes(props.color)) {
-      return props.theme.colors[props.color];
-    }
-    return props.color;
-  }};
-  font-weight: ${(props: any): string | number => {
-    if (
-      (typeof props.weight === 'number' || typeof props.weight === 'string') &&
-      Object.keys(props.theme.typography.weights).includes(props.weight)
-    ) {
-      return props.theme.typography.weights[props.weight];
-    }
-    return props.weight;
-  }};
-`;
-
-// TODO duplicated code
-const StyledParagraph = styled.p<{
-  theme: PUITheme;
-  size?: string | TextSize;
-  weight?: string | number;
+  color?: string | EnumColors;
 }>`
   font-size: ${(props: any): number | string => {
     if (typeof props.size === 'string' && Object.keys(props.theme.typography.sizes).includes(props.size)) {
@@ -95,14 +54,13 @@ const StyledParagraph = styled.p<{
 
 export const Text = React.forwardRef<HTMLElement, TextProps>(
   (
-    { color = 'inherit', size = 'inherit', weight = 'inherit', children, component, ...props }: TextProps,
+    { color = 'inherit', size = 'inherit', weight = 'inherit', children, component = 'span', ...props }: TextProps,
     ref,
   ): JSX.Element => {
     const theme = useTheme();
-    const StyledComponent = component === 'p' ? StyledParagraph : StyledSpan;
 
     return (
-      <StyledComponent theme={theme} color={color} size={size} weight={weight} ref={ref} {...props}>
+      <StyledComponent as={component} theme={theme} color={color} size={size} weight={weight} ref={ref} {...props}>
         {children}
       </StyledComponent>
     );

--- a/stories/chip/index.jsx
+++ b/stories/chip/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Chip, Row, Col } from 'components';
 import ChipDocs from 'components/chip/DOCS.md';
 import README from 'components/chip/README.md';
+import { Icon } from 'components/icon';
 import { decorator } from '../../utils/decorator';
 import { WrappedComponent } from '../helpers/wrapped';
 
@@ -14,7 +15,7 @@ export default decorator('Chip', ChipDocs, README).add('Chip component', () => {
     <WrappedComponent>
       <Row style={{ justifyContent: 'space-around' }}>
         <Col s="2" m="4" l="3">
-          <Chip checked={isChecked1} onClick={() => setChecked1(!isChecked1)}>
+          <Chip checked={isChecked1} uncheckedIcon={Icon.icons.close} onClick={() => setChecked1(!isChecked1)}>
             Chip
           </Chip>
         </Col>


### PR DESCRIPTION
- Allow to also render icon when Chip is not checked
- Remove text and icon props from Chip component (styles that are passed through props can be changed using global classnames of text and icon)
- Allow to pass any component to <Text />, including react classes, not only 'span' and 'p'