### PR TITLE
fix: accordion partly overlapped using grid layout

### DIFF
--- a/src/components/accordion/primary/style.ts
+++ b/src/components/accordion/primary/style.ts
@@ -5,6 +5,7 @@ export const StyledAccordionPrimary = styled.div<{
   theme: PUITheme;
   mode: ThemeMode;
 }>`
+  position: relative;
   display: flex;
   flex-direction: column;
   border-radius: 4px;

--- a/src/components/accordion/secondary/style.ts
+++ b/src/components/accordion/secondary/style.ts
@@ -6,6 +6,7 @@ export const StyledAccordionSecondary = styled.div<{
   theme: PUITheme;
   mode: ThemeMode;
 }>`
+  position: relative;
   display: flex;
   flex-direction: column;
   border: none;


### PR DESCRIPTION
When using few _**accordion**_ components within sequentional grid rows, they make themselves partly unclickable on the bottom part. 
This changes fix this issue.