### PR TITLE
feat: warning, alert, success buttons added

### DIFF
--- a/src/components/button/button-DOCS.md
+++ b/src/components/button/button-DOCS.md
@@ -3,7 +3,7 @@
 Button component
 
 ```js
-import { PrimaryButton, SecondaryButton, Button, WarningButton, AlertButton, SucessButton, ButtonProps } from '@panenco/ui';
+import { PrimaryButton, SecondaryButton, Button, WarningButton, AlertButton, SuccessButton, ButtonProps } from '@panenco/ui';
 ```
 
 <!-- STORY -->

--- a/src/components/button/button-DOCS.md
+++ b/src/components/button/button-DOCS.md
@@ -3,7 +3,7 @@
 Button component
 
 ```js
-import { PrimaryButton, SecondaryButton, Button, ButtonProps } from '@panenco/ui';
+import { PrimaryButton, SecondaryButton, Button, WarningButton, AlertButton, SucessButton, ButtonProps } from '@panenco/ui';
 ```
 
 <!-- STORY -->

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -105,8 +105,8 @@ export const AlertButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ),
 );
 
-export const SucessButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+export const SuccessButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, iconClassName, ...props }: ButtonProps, ref): JSX.Element => (
-    <Button ref={ref} className={cx('buttonSucess', className)} iconClassName={iconClassName} {...props} />
+    <Button ref={ref} className={cx('buttonSuccess', className)} iconClassName={iconClassName} {...props} />
   ),
 );

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -92,3 +92,21 @@ export const SecondaryButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
     <Button ref={ref} className={cx('buttonSecondary', className)} iconClassName={iconClassName} {...props} />
   ),
 );
+
+export const WarningButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, iconClassName, ...props }: ButtonProps, ref): JSX.Element => (
+    <Button ref={ref} className={cx('buttonWarning', className)} iconClassName={iconClassName} {...props} />
+  ),
+);
+
+export const AlertButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, iconClassName, ...props }: ButtonProps, ref): JSX.Element => (
+    <Button ref={ref} className={cx('buttonAlert', className)} iconClassName={iconClassName} {...props} />
+  ),
+);
+
+export const SucessButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, iconClassName, ...props }: ButtonProps, ref): JSX.Element => (
+    <Button ref={ref} className={cx('buttonSucess', className)} iconClassName={iconClassName} {...props} />
+  ),
+);

--- a/src/components/button/style.ts
+++ b/src/components/button/style.ts
@@ -133,6 +133,75 @@ export const StyledButton = styled.button<{
     }
   }
 
+  &.buttonWarning {
+    border: 2px solid
+    ${(props: any): string => {
+      return props.color || (props.mode === ThemeMode.dark ? 'transparent' : props.theme.colors.error);
+    }};
+    background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+      getBackgroundColor(variant, mode, colors.error, colors.error)};
+    color: ${(props: any): string =>
+      props.color || (props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.base100)};
+    padding: 10px 22px;
+    &:hover {
+      background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+        getBackgroundColor(variant, mode, colors.error, colors.error)};
+      color: ${(props: any): string =>
+        props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.base100};
+      opacity: 0.7;
+    }
+    &:active {
+      background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+        getBackgroundColor(variant, mode, colors.error, colors.error)};
+    }
+  }
+
+  &.buttonAlert {
+    border: 2px solid
+    ${(props: any): string => {
+      return props.color || (props.mode === ThemeMode.dark ? 'transparent' : props.theme.colors.alert);
+    }};
+    background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+      getBackgroundColor(variant, mode, colors.alert, colors.alert)};
+    color: ${(props: any): string =>
+      props.color || (props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.base100)};
+    padding: 10px 22px;
+    &:hover {
+      background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+        getBackgroundColor(variant, mode, colors.alert, colors.alert)};
+      color: ${(props: any): string =>
+        props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.base100};
+      opacity: 0.7;
+    }
+    &:active {
+      background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+        getBackgroundColor(variant, mode, colors.alert, colors.alert)};
+    }
+  }
+
+  &.buttonSucess {
+    border: 2px solid
+    ${(props: any): string => {
+      return props.color || (props.mode === ThemeMode.dark ? 'transparent' : props.theme.colors.success);
+    }};
+    background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+      getBackgroundColor(variant, mode, colors.success, colors.success)};
+    color: ${(props: any): string =>
+      props.color || (props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.base100)};
+    padding: 10px 22px;
+    &:hover {
+      background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+        getBackgroundColor(variant, mode, colors.success, colors.success)};
+      color: ${(props: any): string =>
+        props.mode === ThemeMode.dark ? props.theme.colors.primary : props.theme.colors.base100};
+      opacity: 0.7;
+    }
+    &:active {
+      background-color: ${({ variant, mode, theme: { colors } }: any): string =>
+        getBackgroundColor(variant, mode, colors.success, colors.success)};
+    }
+  }
+
   @keyframes load-animation {
     0% {
       -webkit-transform: rotate(0deg);

--- a/src/components/button/style.ts
+++ b/src/components/button/style.ts
@@ -179,7 +179,7 @@ export const StyledButton = styled.button<{
     }
   }
 
-  &.buttonSucess {
+  &.buttonSuccess {
     border: 2px solid
     ${(props: any): string => {
       return props.color || (props.mode === ThemeMode.dark ? 'transparent' : props.theme.colors.success);

--- a/stories/buttons/index.jsx
+++ b/stories/buttons/index.jsx
@@ -1,4 +1,4 @@
-import { Button, ButtonIcon, Col, Icon, PrimaryButton, Row, SecondaryButton } from 'components';
+import { Button, ButtonIcon, Col, Icon, PrimaryButton, Row, SecondaryButton, WarningButton, AlertButton, SucessButton } from 'components';
 import ButtonIconDocs from 'components/button-icon/icon-button-DOCS.md';
 import ButtonIconReadme from 'components/button-icon/icon-button-README.md';
 import ButtonDocs from 'components/button/button-DOCS.md';
@@ -111,6 +111,93 @@ export default decorator('Button', ButtonDocs, ButtonReadme).add('Button compone
               <Button style={buttonStyles} className="mb-1" variant="outlined" isLoading>
                 Outlined
               </Button>
+            </div>
+          </Col>
+        </Row>
+        <Row style={{ justifyContent: 'center', flexGrow: '1' }}>
+          <Col xs="6" md="6" lg="6" style={buttonCellStyles}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <WarningButton style={buttonStyles} className="mb-1" variant="outlined">
+                Warning
+              </WarningButton>
+            </div>
+          </Col>
+
+          <Col xs="6" md="6" lg="6" style={buttonCellStyles}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <WarningButton style={buttonStyles} className="mb-1" variant="outlined" isLoading>
+                Warning
+              </WarningButton>
+            </div>
+          </Col>
+        </Row>
+        <Row style={{ justifyContent: 'center', flexGrow: '1' }}>
+          <Col xs="6" md="6" lg="6" style={buttonCellStyles}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <AlertButton style={buttonStyles} className="mb-1">
+                Alert
+              </AlertButton>
+            </div>
+          </Col>
+
+          <Col xs="6" md="6" lg="6" style={buttonCellStyles}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <AlertButton style={buttonStyles} className="mb-1" variant="outlined" isLoading>
+                Alert
+              </AlertButton>
+            </div>
+          </Col>
+        </Row>
+        <Row style={{ justifyContent: 'center', flexGrow: '1' }}>
+          <Col xs="6" md="6" lg="6" style={buttonCellStyles}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <SucessButton style={buttonStyles} className="mb-1" variant="text">
+                Sucess
+              </SucessButton>
+            </div>
+          </Col>
+
+          <Col xs="6" md="6" lg="6" style={buttonCellStyles}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <SucessButton style={buttonStyles} className="mb-1" variant="outlined" isLoading>
+                Sucess
+              </SucessButton>
             </div>
           </Col>
         </Row>

--- a/stories/buttons/index.jsx
+++ b/stories/buttons/index.jsx
@@ -1,4 +1,4 @@
-import { Button, ButtonIcon, Col, Icon, PrimaryButton, Row, SecondaryButton, WarningButton, AlertButton, SucessButton } from 'components';
+import { Button, ButtonIcon, Col, Icon, PrimaryButton, Row, SecondaryButton, WarningButton, AlertButton, SuccessButton } from 'components';
 import ButtonIconDocs from 'components/button-icon/icon-button-DOCS.md';
 import ButtonIconReadme from 'components/button-icon/icon-button-README.md';
 import ButtonDocs from 'components/button/button-DOCS.md';
@@ -181,9 +181,9 @@ export default decorator('Button', ButtonDocs, ButtonReadme).add('Button compone
                 alignItems: 'center',
               }}
             >
-              <SucessButton style={buttonStyles} className="mb-1" variant="text">
-                Sucess
-              </SucessButton>
+              <SuccessButton style={buttonStyles} className="mb-1" variant="text">
+                Success
+              </SuccessButton>
             </div>
           </Col>
 
@@ -195,9 +195,9 @@ export default decorator('Button', ButtonDocs, ButtonReadme).add('Button compone
                 alignItems: 'center',
               }}
             >
-              <SucessButton style={buttonStyles} className="mb-1" variant="outlined" isLoading>
-                Sucess
-              </SucessButton>
+              <SuccessButton style={buttonStyles} className="mb-1" variant="outlined" isLoading>
+                Success
+              </SuccessButton>
             </div>
           </Col>
         </Row>


### PR DESCRIPTION
https://www.figma.com/file/NAlqiKft9MuxX3QmGQCleQ/Valcori_Application?node-id=6573%3A92643
We need different status buttons: 'Warning', 'Alert', 'Success', in this UI-kit we only have Warning button but in future It can be useful to have different one.