### PR TITLE
fix: popup closing

### DIFF
--- a/src/components/popup/Popup.tsx
+++ b/src/components/popup/Popup.tsx
@@ -67,8 +67,10 @@ export const Popup = React.forwardRef<HTMLDivElement, PopupProps>(
                 tabIndex={-1}
                 role="dialog"
                 aria-modal="true"
-                onClick={backdropClosable && onHide ? onHide : undefined}
                 ref={ref}
+                onMouseDown={(e: React.MouseEvent<HTMLDivElement, MouseEvent>) =>
+                  backdropClosable && e.target === e.currentTarget && onHide ? onHide() : undefined
+                }
               >
                 <StyledPopup
                   size={size}


### PR DESCRIPTION
Want to prevent the modal from closing during selecting text inside popup.
Don't close if it starts inside popup and then ends on backdrop.
https://watch.screencastify.com/v/WSgr37ivN9rgWkZLSCGU