### PR TITLE
fix: set tabIndex for close button

### DIFF
--- a/src/components/popup/PopupHeader.tsx
+++ b/src/components/popup/PopupHeader.tsx
@@ -17,7 +17,7 @@ export const PopupHeader = React.forwardRef<HTMLDivElement, PopupHeaderProps>(
         <div>{children}</div>
         {closeButton && onHide && (
           <div>
-            <ButtonIcon aria-label="Close" onClick={onHide} icon={Icon.icons.delete} />
+            <ButtonIcon aria-label="Close" onClick={onHide} icon={Icon.icons.delete} tabIndex={-1} />
           </div>
         )}
       </StyledPopupHeader>


### PR DESCRIPTION
The problem was that when opening popup, the close button appeared focused