### PR TITLE
fix: omit children in tooltipProps

### DIFF
--- a/src/components/avatar/index.tsx
+++ b/src/components/avatar/index.tsx
@@ -27,7 +27,7 @@ export interface AvatarProps {
   alt?: string;
   size?: number;
   tooltip?: boolean;
-  tooltipProps?: TooltipProps;
+  tooltipProps?: Omit<TooltipProps, 'children'>;
   children?: React.ReactNode | string;
   imgProps?: React.ImgHTMLAttributes<HTMLImageElement>;
 }


### PR DESCRIPTION
Tried using Avatar component with tooltipProps, but it requires children, which I believe is unnecessary here.