### PR TITLE
fix: day picker disabled state

### DIFF
--- a/src/components/form/day-picker/index.tsx
+++ b/src/components/form/day-picker/index.tsx
@@ -190,7 +190,7 @@ export const DayPicker = ({
               showCalendar();
             }
           }}
-          disabled={isCalendarOpen}
+          disabled={isCalendarOpen || dateInputProps?.disable}
           type='text'
           placeholder={placeholder}
           iconAfter={iconAfter}


### PR DESCRIPTION
The problem is there was a prop to disable day picker and this prop was checking only isCalendarOpen state, so i add a check of dateInputProps.disable so user can add some custom prop to disable day picker