### PR TITLE
fix: add ability to use custom sortIcons in table

### DIFF
--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -59,4 +59,4 @@ export const withIcons =
 
 export const Icon = withIcons<typeof defaultIcons>();
 export const icons = defaultIcons;
-export type IconType = React.ReactElement<unknown, string | React.JSXElementConstructor<any>>;
+export type IconType = React.ReactElement<{ className?: string }, string | React.JSXElementConstructor<any>>;

--- a/src/components/responsive-table/header-cell.tsx
+++ b/src/components/responsive-table/header-cell.tsx
@@ -52,8 +52,16 @@ const HeaderCell = ({
         <Text className='tableHeaderText'>{label}</Text>
         {sortName ? (
           <div className='tableHeaderContent'>
-            <Icon icon={sortIcons.up} className={cx('tableHeaderIcon', asc && 'tableHeaderIconActive')} />
-            <Icon icon={sortIcons.down} className={cx('tableHeaderIcon', desc && 'tableHeaderIconActive')} />
+            {React.isValidElement(sortIcons.up) ? (
+              React.cloneElement(sortIcons.up, { className: cx('tableHeaderIcon', asc && 'tableHeaderIconActive') })
+            ) : (
+              <Icon icon={sortIcons.up} className={cx('tableHeaderIcon', asc && 'tableHeaderIconActive')} />
+            )}
+            {React.isValidElement(sortIcons.down) ? (
+              React.cloneElement(sortIcons.down, { className: cx('tableHeaderIcon', desc && 'tableHeaderIconActive') })
+            ) : (
+              <Icon icon={sortIcons.down} className={cx('tableHeaderIcon', desc && 'tableHeaderIconActive')} />
+            )}
           </div>
         ) : null}
       </button>

--- a/src/components/responsive-table/types.ts
+++ b/src/components/responsive-table/types.ts
@@ -47,8 +47,8 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
 }
 
 export interface SortIconsType {
-  up: keyof typeof icons.sm;
-  down: keyof typeof icons.sm;
+  up: IconType | keyof typeof icons.sm;
+  down: IconType | keyof typeof icons.sm;
 }
 
 export interface TableState {


### PR DESCRIPTION
When using new Icons it's not possible to pass custom icons as sortIcons in ResponsiveTable component.