### PR TITLE
fix: resize textarea component on changing initial values

### DIFF
--- a/src/components/form/text-area/index.tsx
+++ b/src/components/form/text-area/index.tsx
@@ -39,6 +39,8 @@ export const TextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(
     const textareaRef = React.createRef() as any;
     const useCombinedrefs = useCombinedRefs(textareaRef, inputRef);
 
+    const { value } = props;
+
     React.useEffect(() => {
       useCombinedrefs.current = textareaRef.current;
     });
@@ -59,8 +61,10 @@ export const TextArea = React.forwardRef<HTMLDivElement, TextAreaProps>(
     };
 
     React.useEffect(() => {
-      recalculateHeight();
-    }, []);
+      if (value && counter === 0) {
+        recalculateHeight(String(value));
+      }
+    }, [value]);
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
       recalculateHeight(event.target.value);


### PR DESCRIPTION
When using textarea in edit mode of some entity without global page loader (component is mounted instantly without initialValues), it doesn't change its height to fit content received from server afterwards. Here I subscribe to `value` prop to check for changes triggered not by `onChange` handler and resize component when there was no data from the beginning.