### PR TITLE
feat: add possibility to disable focus on button click

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -16,7 +16,6 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   iconLeft?: any;
   iconRight?: any;
   isLoading?: boolean;
-  focusDisabled?: boolean;
   to?: string;
   variant?: ButtonVariantType;
 }
@@ -38,7 +37,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'text',
       color,
       isLoading,
-      focusDisabled,
       ...props
     }: ButtonProps,
     ref,
@@ -52,13 +50,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         as={component === 'link' ? Link : component}
         type={type}
         disabled={isDisabled}
-        className={cx(
-          iconLeft && 'iconLeft',
-          iconRight && 'iconRight',
-          isDisabled && 'isDisabled',
-          focusDisabled && 'focusDisabled',
-          className,
-        )}
+        className={cx(iconLeft && 'iconLeft', iconRight && 'iconRight', isDisabled && 'isDisabled', className)}
         theme={theme}
         ref={ref}
         color={color}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -16,6 +16,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   iconLeft?: any;
   iconRight?: any;
   isLoading?: boolean;
+  focusDisabled?: boolean;
   to?: string;
   variant?: ButtonVariantType;
 }
@@ -37,6 +38,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       variant = 'text',
       color,
       isLoading,
+      focusDisabled,
       ...props
     }: ButtonProps,
     ref,
@@ -50,7 +52,13 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         as={component === 'link' ? Link : component}
         type={type}
         disabled={isDisabled}
-        className={cx(iconLeft && 'iconLeft', iconRight && 'iconRight', isDisabled && 'isDisabled', className)}
+        className={cx(
+          iconLeft && 'iconLeft',
+          iconRight && 'iconRight',
+          isDisabled && 'isDisabled',
+          focusDisabled && 'focusDisabled',
+          className,
+        )}
         theme={theme}
         ref={ref}
         color={color}

--- a/src/components/button/style.ts
+++ b/src/components/button/style.ts
@@ -53,12 +53,7 @@ export const StyledButton = styled.button<{
     padding: 10px 16px 10px 22px;
   }
 
-  &.focusDisabled:focus:not(:focus-visible) {
-    outline: 0;
-    box-shadow: none;
-  }
-
-  &:focus {
+  &:focus-visible {
     box-shadow: 0 0 0 2px ${(props: any): string => props.theme.colors.base900};
     z-index: 10;
   }

--- a/src/components/button/style.ts
+++ b/src/components/button/style.ts
@@ -53,11 +53,9 @@ export const StyledButton = styled.button<{
     padding: 10px 16px 10px 22px;
   }
 
-  &.focusDisabled {
-    &:focus:not(:focus-visible) {
-      outline: 0;
-      box-shadow: none;
-    }
+  &.focusDisabled:focus:not(:focus-visible) {
+    outline: 0;
+    box-shadow: none;
   }
 
   &:focus {

--- a/src/components/button/style.ts
+++ b/src/components/button/style.ts
@@ -53,6 +53,13 @@ export const StyledButton = styled.button<{
     padding: 10px 16px 10px 22px;
   }
 
+  &.focusDisabled {
+    &:focus:not(:focus-visible) {
+      outline: 0;
+      box-shadow: none;
+    }
+  }
+
   &:focus {
     box-shadow: 0 0 0 2px ${(props: any): string => props.theme.colors.base900};
     z-index: 10;


### PR DESCRIPTION
Solution allows to remove after-click focus apperance on button without affecting navigation through `Tab`. Despite the property used here is relatively new, as described in [this](https://stackoverflow.com/questions/19053181/how-to-remove-focus-around-buttons-on-click) article, it's a good compromise (at least for my case:). 