### PR TITLE
fix: pass textInputValue to TextInput component

### DIFF
--- a/src/components/form/day-picker/index.tsx
+++ b/src/components/form/day-picker/index.tsx
@@ -236,6 +236,7 @@ export const DayPicker = ({
               error={error}
               dir={dayPickerProps?.dir || dir}
               inputRef={customRef}
+              value={textInputValue}
               {...dateInputProps}
               {...restProps}
             />


### PR DESCRIPTION
There is a bug in DatePicker component, when selecting a value from calendar it does not update the text input value event though the date value is correct (see the video below)


https://user-images.githubusercontent.com/65604728/211035884-eec380bd-d874-40ce-b96e-1a32e1f6a1b6.mov

